### PR TITLE
feat: release version 3.1.0 with internationalization improvements an…

### DIFF
--- a/.cnb.yml
+++ b/.cnb.yml
@@ -29,7 +29,7 @@ $:
         - name: show version
           script: node -v
         - name: install
-          script: npm install -g pnpm && pnpm install --no-frozen-lockfile --verbose
+          script: npm install -g pnpm && pnpm install --no-frozen-lockfile
         - name: build
           script: pnpm run build
         - name: update version

--- a/docs/src/develop/changelog/_versions/3.1.0.md
+++ b/docs/src/develop/changelog/_versions/3.1.0.md
@@ -1,0 +1,13 @@
+## <span class="changelog-version">3.1.0</span><span class="changelog-date">2026-08-30</span>
+
+完善组件国际化能力，修复发布后 UnoCSS 工具类样式缺失。
+
+### 新功能
+
+- **国际化（i18n）**：新增 `zh-CN` / `en-US` 语言包与 `useLocale`，组件内置文案统一走语言包
+- **ConfigProvider**：新增 `localeMessages`，可按组件局部覆盖文案；`locale` 切换后 Modal、Drawer、Popconfirm、Pagination、Table、DatePicker、TimePicker 等自动跟随
+- 上述组件的 `okText` / `cancelText` / `title` / `emptyText` / 分页模板等默认值改为空字符串，未传入时回退到当前语言包
+
+### 修复
+
+- **样式产物**：构建时将 UnoCSS 工具类合并进 `theme/index.css`、`dist/index.css`，并按组件注入到按需 `theme/*.css`，修复安装后 `mr-1` 等工具类失效的问题

--- a/docs/src/develop/changelog/index.md
+++ b/docs/src/develop/changelog/index.md
@@ -3,4 +3,6 @@ title: 更新日志
 pageClass: bp-changelog-page
 ---
 
+<!--@include: @/develop/changelog/_versions/3.1.0.md-->
+
 <!--@include: @/develop/changelog/_versions/3.0.0.md-->

--- a/docs/src/en/develop/changelog/_versions/3.1.0.md
+++ b/docs/src/en/develop/changelog/_versions/3.1.0.md
@@ -1,0 +1,13 @@
+## <span class="changelog-version">3.1.0</span><span class="changelog-date">2026-08-30</span>
+
+Improves component internationalization and fixes missing UnoCSS utilities in published styles.
+
+### Features
+
+- **i18n**: Adds `zh-CN` / `en-US` locale packs and `useLocale`; built-in component copy is driven by the active locale
+- **ConfigProvider**: Adds `localeMessages` for partial overrides; switching `locale` updates Modal, Drawer, Popconfirm, Pagination, Table, DatePicker, TimePicker, and related components
+- Defaults for `okText` / `cancelText` / `title` / `emptyText` / pagination templates on those components are now empty strings and fall back to the active locale pack when omitted
+
+### Fixes
+
+- **Style build**: Merges UnoCSS utilities into `theme/index.css` and `dist/index.css`, and injects per-component rules into on-demand `theme/*.css`, fixing missing utilities such as `mr-1` after install

--- a/docs/src/en/develop/changelog/index.md
+++ b/docs/src/en/develop/changelog/index.md
@@ -3,4 +3,6 @@ title: Changelog
 pageClass: bp-changelog-page
 ---
 
+<!--@include: @/en/develop/changelog/_versions/3.1.0.md-->
+
 <!--@include: @/en/develop/changelog/_versions/3.0.0.md-->


### PR DESCRIPTION
…d UnoCSS fixes

- Enhanced component internationalization by adding `zh-CN` and `en-US` locale packs and a new `useLocale` feature.
- Updated `ConfigProvider` to support partial overrides of locale messages and automatic updates for various components upon locale change.
- Fixed issues with missing UnoCSS utility classes in published styles by merging them into the appropriate CSS files during the build process.
- Updated changelog to reflect the new version and changes made.